### PR TITLE
Suppress all modal messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,19 +241,6 @@
             "markdownDescription": "(`Windows only`) On startup, a info window pops if you haven't set your custom system includes.",
             "scope": "resource"
           },
-          "unreal-clangd.gui.errorToWarning": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "no-rsp-path-match"
-              ]
-            },
-            "default": [],
-            "description": "Array of error names to downgrade from error to warning.",
-            "uniqueItems": true,
-            "scope": "resource"
-          },
           "unreal-clangd.automation": {
             "type": "array",
             "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -335,7 +335,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('unreal-clangd.toggleMacroCompletions', async () => {
 		if(_isTogglingMacroCompletions) {
-			await vscode.window.showInformationMessage(
+			await vscode.window.showWarningMessage(
 				"Clicked UC button too quickly."
 			);
 			return;

--- a/src/libs/console.ts
+++ b/src/libs/console.ts
@@ -2,54 +2,143 @@
  * Override for console so it shows console messages for both developer and user
  */
 
-import * as vscode from 'vscode';
-import process from 'node:process';
-import { EXTENSION_NAME } from './consts';
+import * as vscode from "vscode";
+import process from "node:process";
+import { EXTENSION_NAME } from "./consts";
 
-export const outputChannel: vscode.OutputChannel | undefined = vscode.window.createOutputChannel(EXTENSION_NAME);
+export type LogLevel = "info" | "warn" | "error" | "debug";
+
+export interface LogOptions {
+	/** An optional scope tag, e.g., 'semantic' -> <semantic> */
+	tag?: string;
+	/** If true, shows a VS Code modal/toast notification to the user */
+	showModal?: boolean;
+	messageOption?: vscode.MessageOptions;
+}
+
+export const outputChannel: vscode.LogOutputChannel | undefined =
+	vscode.window.createOutputChannel(EXTENSION_NAME, { log: true });
 
 const IS_DEBUG = !!process.env.IS_DEBUGGING_VSCEXT;
 let errorCount = 0;
 let warningCount = 0;
+let duplicateCount = 0;
+let lastLogKey = "";
 
-
-export function log(message: string) {
-    
-    if (IS_DEBUG) { console.log(message); }
-    outputChannel?.appendLine(message);
+function flushDuplicates() {
+	if (duplicateCount > 0) {
+		outputChannel?.appendLine(
+			`   ↳ [Suppressed ${duplicateCount.toString()} identical duplicate log lines]`,
+		);
+		duplicateCount = 0;
+	}
 }
 
+function _log(
+	level: LogLevel,
+	message: string,
+	options: LogOptions = {},
+): void {
+	const tagPrefix = options.tag ? `<${options.tag}> ` : "";
+	const formattedMessage = `${tagPrefix}${message}`;
+	const logKey = `${level}:${formattedMessage}`;
+
+	// Handle Duplicates
+	if (logKey === lastLogKey) {
+		duplicateCount++;
+		// Silently suppress continuous duplicates, or you can choose to flush
+		// a "Last message repeated X times" line when the key changes.
+		return;
+	} else {
+		flushDuplicates();
+		lastLogKey = logKey;
+	}
+
+	// Route to native VS Code LogOutputChannel (handles timestamps and [level] flags)
+	switch (level) {
+		case "info":
+			outputChannel?.info(formattedMessage);
+			if (options.showModal) {
+				vscode.window.showInformationMessage(
+					message,
+					options.messageOption ?? {},
+				);
+			}
+			break;
+		case "warn":
+			outputChannel?.warn(formattedMessage);
+			if (options.showModal) {
+				vscode.window.showWarningMessage(
+					message,
+					options.messageOption ?? {},
+				);
+			}
+			break;
+		case "error":
+			outputChannel?.error(formattedMessage);
+			// Modals for errors usually benefit from an explicit anchor action or modal flag
+			if (options.showModal) {
+				vscode.window.showErrorMessage(
+					message,
+					options.messageOption ?? {},
+				);
+			}
+			break;
+		case "debug":
+			outputChannel?.debug(formattedMessage);
+			break;
+	}
+}
+
+export function log(message: string): void;
+export function log(logLevel: LogLevel, message: string): void;
+export function log(a: string, b?: string) {
+	if (typeof b === "undefined") {
+		// single-argument: treat as info
+		const message = a;
+		if (IS_DEBUG) {
+			console.log(message);
+		}
+		_log("info", message);
+		return;
+	}
+
+	const level = a as LogLevel;
+	const message = b;
+	_log(level, message);
+}
 
 export function error(message: string) {
-    errorCount += 1;
+	errorCount += 1;
 
-    if (IS_DEBUG) { console.error(message); }
+	if (IS_DEBUG) {
+		console.error(message);
+	}
 
-    if(!outputChannel) {return;}
-    outputChannel.appendLine("** Error **: ".concat(message));
-    outputChannel.show();
+	if (!outputChannel) {
+		return;
+	}
+	_log("error", message, { modal: true });
 }
-
 
 export function warn(message: string) {
-    warningCount += 1;
+	warningCount += 1;
 
-    if (IS_DEBUG) { console.error(message); }
-    outputChannel?.appendLine("** Warning **: ".concat(message));
+	if (IS_DEBUG) {
+		console.error(message);
+	}
+	_log("warn", message);
 }
-
 
 export function resetCounts() {
-    errorCount = 0;
-    warningCount = 0;
+	errorCount = 0;
+	warningCount = 0;
 }
-
 
 export function getErrorCount() {
-    return errorCount;
+	return errorCount;
 }
 
-
 export function getWarningCount() {
-    return warningCount;
+	return warningCount;
 }

--- a/src/libs/projHelpers.ts
+++ b/src/libs/projHelpers.ts
@@ -430,10 +430,9 @@ export async function setProjectSetting(
 export async function askToReloadVSCode() {
 
     const result = await vscode.window.showInformationMessage(
-        "Extension needs to reload VSCode...",
+        "Extension needs to reload VSCode. Do you want to reload now?",
         {
-            detail: "Choose Cancel if you need to read logs, save files, etc.\n\nAfter cancelling, manually restart VSCode after your done.",
-            modal: true
+            modal: false
         },
         "Reload"
     );

--- a/src/modules/addToUeSourceCC.ts
+++ b/src/modules/addToUeSourceCC.ts
@@ -88,13 +88,7 @@ async function addFilesToUESourceCompileCommands(
     const rspPathRelative = getSourceFileRspPathMatch(ueUri, currentDocUri);
 
     if(!rspPathRelative){
-        if(isErrorNoRspPathMatch(projectUri)){
-            console.error(`No RSP path match found for: ${currentDocUri.fsPath}`);
-        }
-        else {
-            console.warn(`No RSP path match found for: ${currentDocUri.fsPath}`);
-        }
-        return;
+        console.error(`No RSP path match found for: ${currentDocUri.fsPath}`);
     }
 
     const ccName = await getProjectCompileCommandsName();
@@ -263,18 +257,3 @@ function findClosestUri(uris: vscode.Uri[], targetUri: vscode.Uri) {
 
     return closestUri;
 }
-
-
-function isErrorNoRspPathMatch(configScopeUri: vscode.Uri) {
-
-    const config = vscode.workspace.getConfiguration("unreal-clangd.gui", configScopeUri);
-
-    const value = config.get<string[]>("errorToWarning", []);
-
-    if(value.includes("no-rsp-path-match")){
-        return false;
-    }
-    
-    return true;
-}
-

--- a/src/modules/backupWorkspace.ts
+++ b/src/modules/backupWorkspace.ts
@@ -87,11 +87,12 @@ async function handleRestoreClangdSettings(projWorkspaceFolder: vscode.Workspace
     const isAlwaysRestoreFromBackup = backupExists && getAutomationIsSet("restore-from-backup-when-available", projWorkspaceFolder);
 
     const choices = backupExists ? ["Restore from backup", "Run project installation"] : ["Run project installation"];
+    const message = msg ?? "Clangd settings not found in your Workspace File! This could be because you refreshed your project without using this extension's `Update compile commands file (refresh project)` command, which prevents this from happening.";
+    const backupMessage = backupExists ? "Restore: Restore from backup file\nInstall: Run partial install for starter settings" : "Install: Run partial install for starter settings";
     const result = isAlwaysRestoreFromBackup ? "Restore from backup" : await vscode.window.showWarningMessage(
-        msg ?? "Clangd settings not found in your Workspace File! This could be because you refreshed your project without using this extension's `Update compile commands file (refresh project)` command, which prevents this from happening.",
+        `${message} ${backupMessage}`,
         {
-            detail: backupExists ? "Restore: Restore from backup file\nInstall: Run partial install for starter settings" : "Install: Run partial install for starter settings",
-            modal: true
+            modal: false
         },
         ...choices
     );
@@ -208,7 +209,7 @@ async function previewBackupFileAndPrompt(backupUri: vscode.Uri) {
 
     let selection;
     for (;;) {
-        selection = await vscode.window.showInformationMessage(message, {detail: detail, modal: true}, "Page Up", "Page Down", 'Proceed');
+        selection = await vscode.window.showInformationMessage(`${message} ${detail}`, {modal: false}, "Page Up", "Page Down", 'Proceed');
         if(selection !== "Page Down" && selection !== "Page Up") {
             break;
         }

--- a/src/modules/createProject.ts
+++ b/src/modules/createProject.ts
@@ -57,7 +57,7 @@ export async function createUnrealClangdProject(): Promise<"ran" | "cancelled"> 
 
     const creatingProjectAfterReload = ueClangdConfig.get<string>(consts.settingNames.unrealClangd.settings['utility.createProjectOnStartup']);
     if (!creatingProjectAfterReload && !getIsWantingToCreate()) {
-        const installTypeResult = await vscode.window.showWarningMessage(tr.WHAT_INSTALL_TYPE, { detail: tr.FULL_OR_PARTIAL, modal: true }, tr.BTTN_FULL, tr.BTTN_PARTIAL);
+        const installTypeResult = await vscode.window.showWarningMessage(`${tr.WHAT_INSTALL_TYPE} ${tr.FULL_OR_PARTIAL}`, { modal: false }, tr.BTTN_FULL, tr.BTTN_PARTIAL);
 
         if (!installTypeResult) {
             return "cancelled";
@@ -138,7 +138,7 @@ export async function finishCreationAfterUpdateCompileCommands() {
     setCreationCmdLineDynamicValues(mainWorkspaceFolder, creationCmdLine, uePlatform);
     const cmdLineString = getCmdLineString(creationCmdLine);
 
-    const result = await vscode.window.showInformationMessage(tr.CREATION_CMD_LINE_OPTIONS, { detail: cmdLineString, modal: true }, tr.BTTN_OK);
+    const result = await vscode.window.showInformationMessage(`${tr.CREATION_CMD_LINE_OPTIONS} ${cmdLineString}`, { modal: true }, tr.BTTN_OK);
 
     if (result !== tr.BTTN_OK) {
         console.log(tr.ERR_NO_CREATION_ARGS_WERE_FOUND);
@@ -211,11 +211,12 @@ export async function finishCreationAfterUpdateCompileCommands() {
         //await startConvertUnrealCompileCommands(); // Do we need this if they're going to reload? This will also run on reload/restart...
     }
     
+    const message = `Unreal-clangd project creation successful!${EOL}${EOL}Choose 'Reload' to reload the VSCode window to finish creation.`;
+    const detailMessage = "If you need to read some log files then you can skip this. Restart VSCode after you're done reading logs.";
     const endCreationResult = await vscode.window.showInformationMessage(
-        `Unreal-clangd project creation successful!${EOL}${EOL}Choose 'Reload' to reload the VSCode window to finish creation.`,
+        `${message} ${detailMessage}`,
         {
-            detail: "If you need to read some log files then you can skip this. Restart VSCode after you're done reading logs.",
-            modal: true
+            modal: false
         },
         "Reload", "Skip"
     );
@@ -291,8 +292,8 @@ async function handleExtensionConflict(workspaceFolder: vscode.WorkspaceFolder):
     }
 
     const results = await vscode.window.showInformationMessage(
-        tr.INFO_SET_CONFLICT_SETTINGS,
-        {modal:true, detail: tr.WARN_CONFLICT_SETTINGS_RELOAD},
+        `${tr.INFO_SET_CONFLICT_SETTINGS} ${tr.WARN_CONFLICT_SETTINGS_RELOAD}`,
+        {modal:false},
         tr.BTTN_OK);
 
     if(results !== tr.BTTN_OK){
@@ -411,10 +412,10 @@ function isValidUnrealVersion(userVersion: ueH.UnrealVersion | null, extensionVe
 }
 
 
-async function isOkWithWarning(text: string, detail: string, modal = true): Promise<boolean> {
+async function isOkWithWarning(text: string, detail: string, modal = false): Promise<boolean> {
     const results = await vscode.window.showWarningMessage(
-        text,
-        { detail: detail, modal: modal },
+        `${text} ${detail}`,
+        { modal: modal },
         tr.BTTN_CONTINUE);
 
     if (results === tr.BTTN_CONTINUE) {
@@ -665,7 +666,7 @@ export async function createUnrealSourceProject() {
     const ueUri = ueH.getUnrealUri();
 
     if(!ueUri){
-        await vscode.window.showInformationMessage("Error creating Unreal Source project!");
+        await vscode.window.showErrorMessage("Error creating Unreal Source project!");
         return;
     }
 
@@ -679,7 +680,7 @@ export async function createUnrealSourceProject() {
     const ueVersion = await ueH.getUnrealVersion();
     if(!ueVersion){
         console.error("Couldn't get ueVersion!");
-        await vscode.window.showInformationMessage("Error creating Unreal Source project!");
+        await vscode.window.showErrorMessage("Error creating Unreal Source project!");
         return;
     }
     
@@ -751,8 +752,6 @@ export async function createUnrealSourceProject() {
 
     await vscode.window.showInformationMessage(
         `Installation successful!${EOL}${EOL}Finished creating Unreal Source project`,
-        { modal: true },
-        tr.BTTN_OK
     );
 }
 
@@ -761,7 +760,7 @@ async function getAddForClangdCfg(platform: NodeJS.Platform, ueVersion: ueH.Unre
     const cppVersion = dyn.getCppVersion(ueVersion);
     if(!cppVersion){
         console.error("Couldn't get cppVersion for Add in .clangd(UE Source)!");
-        await vscode.window.showInformationMessage("Error creating Unreal Source project!");
+        await vscode.window.showErrorMessage("Error creating Unreal Source project!");
         return;
     }
 

--- a/src/modules/createRspMatchers.ts
+++ b/src/modules/createRspMatchers.ts
@@ -166,7 +166,7 @@ export async function findRspMatchers(
             continue;
         }
         else {
-            console.warn(`(Probably fine) Didn't find rsp matcher for: ${found.uri.fsPath}`);
+            console.warn(`Didn't find rsp matcher for: ${found.uri.fsPath}`);
         }
         
     }

--- a/src/modules/setCustomSysInc.ts
+++ b/src/modules/setCustomSysInc.ts
@@ -43,9 +43,11 @@ export async function startCheckCustomSystemIncludes(): Promise<void> {
 	await iterateOverProjectFolders( checkCustomSystemIncludesInClangdCfg, async (result, uri) => {
 		if(result === 'okFail'){
 			
+            const message = `Custom System Includes not found!${EOL}${EOL}Run 'Set Custom System Includes' now?`;
+            const detail = "note: 'Cancel and never show again' = 'unreal-clangd.systemIncludes.showMissingWarning' and will be set in folder config: .vscode/settings.json";
 			const askRunCCResult = await vscode.window.showWarningMessage(
-				`Custom System Includes not found!${EOL}${EOL}Run 'Set Custom System Includes' now?`,
-				{detail: "note: 'Cancel and never show again' = 'unreal-clangd.systemIncludes.showMissingWarning' and will be set in folder config: .vscode/settings.json",modal: true},
+				`${message} ${detail}`,
+				{modal: false},
 				"Run", "Cancel and never show again"
 			);
 
@@ -201,28 +203,25 @@ async function getLibraryUris(): Promise<{ cppLibUri: vscode.Uri | undefined; sd
 async function confirmProceed(defaultLibraryPaths: string[]): Promise<boolean> {
     const libPaths = defaultLibraryPaths.join(EOL);
 
-    let choice: "See Documentation" | "Continue" | undefined = "See Documentation";
+    const message = `Would you like to change the library versions for this project?${EOL}${EOL}If you don't, clang ` +
+        "will auto choose the libraries below which might be incorrect for your Unreal version. " +
+        "These new settings will be set in your .clangd config files in the 'Add' section." +
+        `${EOL}${EOL}You can install different library versions using the Visual Studio Installer. See documentation.`;
+    const choice = await vscode.window.showInformationMessage(
+        `${message} ${libPaths}`,
+        {
+            modal: false
+        },
+        'See Documentation', 'Continue'
+    );
 
-    while (choice === 'See Documentation') {
-        choice = await vscode.window.showInformationMessage(
-            `Would you like to change the library versions for this project?${EOL}${EOL}If you don't, clang ` +
-            "will auto choose the libraries below which might be incorrect for your Unreal version. " +
-            "These new settings will be set in your .clangd config files in the 'Add' section." +
-            `${EOL}${EOL}You can install different library versions using the Visual Studio Installer. See documentation.`,
-            {
-                detail: libPaths,
-                modal: true
-            },
-            'See Documentation', 'Continue'
-        );
-
-        if(choice === "See Documentation") {
-            const url = vscode.Uri.parse(WEB_VISUAL_STUDIO_INSTALLER_DOCS, true);
-            vscode.env.openExternal(url);
-        }
+    if(choice === "See Documentation") {
+        const url = vscode.Uri.parse(WEB_VISUAL_STUDIO_INSTALLER_DOCS, true);
+        vscode.env.openExternal(url);
+        return false;
     }
 
-    return choice === 'Continue';
+    return true;
 }
 
 
@@ -485,9 +484,10 @@ async function saveCustomLibraryFlagsToClangdConfigs(clangdCfgFolderUri: vscode.
         // Show user any flags that will be replaced
         const replacedValues = getStartsWithFromSequence("getFiltered", SYS_INC_FILTER_PREFIXES, addValues);
         if (replacedValues.length > 0) {
+            const message = `The items below will be replaced in:${EOL}${clangdCfgUri.fsPath}${EOL}${EOL}Do you want to proceed? If the below settings look correct then feel free to 'Skip'.`;
             const choice = await vscode.window.showInformationMessage(
-                `The items below will be replaced in:${EOL}${clangdCfgUri.fsPath}${EOL}${EOL}Do you want to proceed? If the below settings look correct then feel free to 'Skip'.`,
-                { detail: replacedValues.join(EOL), modal: true }, "Skip", "OK"
+                `${message} ${replacedValues.join(EOL)}`,
+                { modal: false }, "Skip", "OK"
             );
 
             if (choice === undefined || choice === "Skip") { 

--- a/src/modules/uninstallExtProj.ts
+++ b/src/modules/uninstallExtProj.ts
@@ -39,10 +39,9 @@ export async function uninstallExtensionProject() {
         const detailString = getDeleteFilesWindowDetailString(projectWorkspaceFolder, ueClangdProjectFiles);
 
         const deleteFilesResult = await vscode.window.showInformationMessage(
-            tr.THESE_WILL_BE_DELETED_PROCEED,
+            `${tr.THESE_WILL_BE_DELETED_PROCEED} ${detailString}`,
             {
-                detail: detailString,
-                modal: true
+                modal: false
             },
             tr.BTTN_DEL, tr.BTTN_TO_TRASH, tr.BTTN_SKIP
         );
@@ -184,10 +183,9 @@ async function askDeleteSettings(extensionName: string, settingNames: Record<str
     }
 
     return await vscode.window.showInformationMessage(
-        `${tr.left_SETTINGS_WILL_BE_DELETED_ext_name}${extensionName} ${tr.right_ext_name_SETTINGS_WILL_BE_DELETED}`,
+        `${tr.left_SETTINGS_WILL_BE_DELETED_ext_name}${extensionName} ${tr.right_ext_name_SETTINGS_WILL_BE_DELETED} ${settingNamesString}`,
         {
-            detail: settingNamesString,
-            modal: true
+            modal: false
         },
         tr.BTTN_ALL, tr.BTTN_PROJECT, tr.BTTN_SKIP
     );

--- a/src/modules/unrealCCChecker.ts
+++ b/src/modules/unrealCCChecker.ts
@@ -60,9 +60,11 @@ async function getCCWithValidResponseFiles(ccs: CompileCommand[]) {
         // Not a file so ask to delete or keep or delete all invalid
         if (choice !== "Remove All") {
             console.error(`Unreal CC invalid rsp path found! ${rspPath}`);
+            const message = `Invalid path found in Unreal's compile_commands.json!\n\nRSP Path:\n${rspPath}`;
+            const detail = "What would you like to do with this invalid path?";
             choice = await vscode.window.showErrorMessage(
-                `Invalid path found in Unreal's compile_commands.json!\n\nRSP Path:\n${rspPath}`,
-                { detail: "What would you like to do with this invalid path?", modal: true },
+                `${message} ${detail}`,
+                { modal: false },
                 "Remove", "Remove All", "Keep"
             );
         }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -214,8 +214,8 @@ export function getAutomationIsSet(automationSetting: "update-CC-on-new-source" 
 
 export async function askAndRunUpdateCompileCommands(buttons: string[], positiveConfirms: string[], message: string, detailMessage: string) {
     const result = await vscode.window.showInformationMessage(
-        message,
-        { modal: true, detail: detailMessage },
+        `${message} ${detailMessage}`,
+        { modal: false },
         ...buttons);
 
     if (result !== undefined && positiveConfirms.includes(result)) {


### PR DESCRIPTION
## Description

Due to excessive focus loss caused by active modals, this PR have downgraded all active modals into passive modals[^1]. The log output has been cleaned and formatted based on `vscode.LogOutputChannel`.

In summary:

* All active modals are set to passive modals
* Format all logs properly using `vscode.LogOutputChannel`
* Suppress all subsequent duplicate logs
* Remove now unused `errorToWarning` config option
* Fix some modals based on the log severity

[^1]: However, by suppressing some modals, some of the extension action might not be obvious and might not be noticed by the end users. For example, There is an obvious delay between updating the intellisense and reloading the current window message.